### PR TITLE
[Registry Android] Fix invalid method `BitmarkSDKModule.validateMetadata`

### DIFF
--- a/android/app/src/main/java/com/bitmark/registry/modules/sdk/BitmarkSDKModule.java
+++ b/android/app/src/main/java/com/bitmark/registry/modules/sdk/BitmarkSDKModule.java
@@ -613,7 +613,8 @@ public class BitmarkSDKModule extends ReactContextBaseJavaModule implements Bitm
 
             Map<String, String> metadata = toStringMap(metadataMap);
             String packedMetadata = RegistrationParams.getPackedMetadata(metadata);
-            if (RAW.decode(packedMetadata).length <= 2048) promise.resolve(true);
+            if (packedMetadata.isEmpty() || RAW.decode(packedMetadata).length <= 2048)
+                promise.resolve(true);
             else promise.resolve(false);
 
         } catch (Throwable e) {


### PR DESCRIPTION
This PR do the following 
- Fix invalid metadata when passing empty metadata.